### PR TITLE
Multi account support

### DIFF
--- a/examples/keygen.go
+++ b/examples/keygen.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+    "fmt"
+    "io/ioutil"
+    "net/http"
+    "os"
+)
+
+func main() {
+    uri := "http://localhost:3000/gen"
+    if len(os.Args) > 1 { 
+        uri = os.Args[1]
+    }
+    response, err := http.Post(uri, "", nil)
+    if err != nil {
+        panic(err)
+    }
+
+    if response == nil {
+        panic("nil response encountered")
+    }
+
+    body := response.Body
+
+	defer body.Close()
+	data, rErr := ioutil.ReadAll(body)
+    if rErr != nil {
+        panic(rErr)
+    }
+
+    fmt.Printf("%s", data)
+}

--- a/models/lease.go
+++ b/models/lease.go
@@ -1,0 +1,19 @@
+package models
+
+import (
+	"time"
+
+	"gopkg.in/mgo.v2/bson"
+)
+
+type Lease struct {
+	Duration     int64
+	AuthorizerId bson.ObjectId
+	CreationDate time.Time
+	PrivateKey   string
+	PublicKey    string
+}
+
+func (l *Lease) Expired() bool {
+	return l.CreationDate.Add(time.Duration(l.Duration)).Before(time.Now())
+}

--- a/models/user.go
+++ b/models/user.go
@@ -12,20 +12,34 @@ const (
 )
 
 type User struct {
+	lastEditTimeTrack
 	Email           string
 	MainPublicKey   string
 	MainPrivateKey  string
 	ExpiryDateEpoch int64
-	Id              *bson.ObjectId
+	id              bson.ObjectId `bson:"_id,omitempty"`
 }
 
 type KeySet struct {
-	PublicKey  string
-	PrivateKey string
-	OwnerId    *bson.ObjectId
-	Id         *bson.ObjectId
+	lastEditTimeTrack
+	PublicKey  string `json:"public_key"`
+	PrivateKey string `json:"private_key"`
+	ownerId    *bson.ObjectId
+	id         bson.ObjectId `bson:"_id,omitempty"`
+}
+
+func (ks *KeySet) SetupBeforeUpdate() {
+	if !ks.id.Valid() {
+		ks.id = bson.NewObjectId()
+	}
+	ks.lastEditTime = time.Now().Unix()
+}
+
+type lastEditTimeTrack struct {
+	lastEditTime int64
 }
 
 func (u *User) Valid() bool {
-	return u.Email != "" && time.Now().Unix() < u.ExpiryDateEpoch
+	// TODO: check email properly
+	return time.Now().Unix() < u.ExpiryDateEpoch
 }

--- a/models/user.go
+++ b/models/user.go
@@ -1,0 +1,31 @@
+package models
+
+import (
+	"time"
+
+	"gopkg.in/mgo.v2/bson"
+)
+
+const (
+	DbName          = "qr-demo-server"
+	KeySetModelName = "keyset"
+)
+
+type User struct {
+	Email           string
+	MainPublicKey   string
+	MainPrivateKey  string
+	ExpiryDateEpoch int64
+	Id              *bson.ObjectId
+}
+
+type KeySet struct {
+	PublicKey  string
+	PrivateKey string
+	OwnerId    *bson.ObjectId
+	Id         *bson.ObjectId
+}
+
+func (u *User) Valid() bool {
+	return u.Email != "" && time.Now().Unix() < u.ExpiryDateEpoch
+}


### PR DESCRIPTION
This PR addresses issue https://github.com/odeke-em/qr-demo-server/issues/1

This PR adds in multi account support and provides primitives for users to get accounts. 
The backend DB used is MongoDB and an example that could be built into a cli is in examples/
